### PR TITLE
Fix args of a pcitest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,19 +408,19 @@ LEGACY IRQ:     OKAY
 
 ### Read Test
 ```
-$ pcitest -r 1024
+$ pcitest -r -s 102400
 READ ( 102400 bytes):           OKAY
 ```
 
 ### Write Test
 ```
-$ pcitest -w 1024
+$ pcitest -w -s 102400
 WRITE ( 102400 bytes):          OKAY
 ```
 
 ### Copy Test
 ```
-$ pcitest -c 1024
+$ pcitest -c -s 102400
 COPY ( 102400 bytes):           OKAY
 ```
 


### PR DESCRIPTION
A size of transter data is specifed by `-s {data size}` argument, like [pcitest.sh](https://github.com/torvalds/linux/blob/e49d033bddf5b565044e2abe4241353959bc9120/tools/pci/pcitest.sh#L48)